### PR TITLE
Use sparklyr 1.0.1 which supports alternate repos

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: This is a sparklyr extension integrating VariantSpark and R. Varian
 License: Apache License 2.0 | file LICENSE
 LazyData: true
 Imports: 
-    sparklyr
+    sparklyr (>= 1.0.1)
 RoxygenNote: 6.1.1
 Suggests: 
     testthat


### PR DESCRIPTION
`sparklyr 1.0.1` is on CRAN so we can force `variantspark` to use this version to ensure the `repositories` dependencies is correctly registered.